### PR TITLE
Fix snapshot leak after successful transactions

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -113,6 +113,15 @@ export class StateManager<TState extends object> {
     }
 
     /**
+     * Discard the last snapshot without altering state
+     */
+    discardLastSnapshot(): void {
+        if (this.snapshots.length > 0) {
+            this.snapshots.pop();
+        }
+    }
+
+    /**
      * Undo the last state change
      */
     undo(): void {

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -208,6 +208,9 @@ export class Transaction<TState extends object, TPayload = unknown> {
           timestamp: Date.now()
         });
 
+        // Remove rollback snapshot since the transaction completed successfully
+        this.stateManager.discardLastSnapshot();
+
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
 

--- a/src/__tests__/Transaction.test.ts
+++ b/src/__tests__/Transaction.test.ts
@@ -158,6 +158,18 @@ describe('Transaction', () => {
                 'transaction:rollback'
             ]);
         });
+
+        it('should remove snapshot after successful execution', async () => {
+            const initialSnapshots = stateManager.snapshotsLength;
+
+            transaction.addStep('increment', (state) => {
+                state.counter += 1;
+            });
+
+            await transaction.run({});
+
+            expect(stateManager.snapshotsLength).toBe(initialSnapshots);
+        });
     });
 
     describe('retry mechanism', () => {


### PR DESCRIPTION
## Summary
- ensure transaction snapshots are discarded after a successful run
- add StateManager helper to drop snapshots without altering state
- test that snapshots aren’t left behind after successful transactions

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688f7be2f6308325b9c81d68030d2647