### PR TITLE
feat: allow custom state cloning

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -5,6 +5,7 @@ export interface StateManagerOptions {
     maxSnapshots?: number;
     autoCleanup?: boolean;
     snapshotInterval?: number; // Create snapshot every N changes for performance
+    clone?: <T>(value: T) => T;
 }
 
 /**
@@ -50,7 +51,7 @@ export class StateManager<TState extends object> {
      * Add a state to the undo stack (for internal use by transactions)
      */
     public addToUndoStack(state: TState): void {
-        this.undoStack.push(structuredClone(state));
+        this.undoStack.push(this.options.clone(state));
         this.redoStack = [];
     }
 
@@ -59,10 +60,11 @@ export class StateManager<TState extends object> {
             maxUndoHistory: options.maxUndoHistory ?? 100,
             maxSnapshots: options.maxSnapshots ?? 20,
             autoCleanup: options.autoCleanup ?? true,
-            snapshotInterval: options.snapshotInterval ?? 10
+            snapshotInterval: options.snapshotInterval ?? 10,
+            clone: options.clone ?? structuredClone
         };
 
-        this.state = structuredClone(initialState);
+        this.state = this.options.clone(initialState);
     }
 
     /**
@@ -77,8 +79,8 @@ export class StateManager<TState extends object> {
      */
     setState(newState: TState): void {
         // Add current state to undo stack
-        this.undoStack.push(structuredClone(this.state));
-        this.state = structuredClone(newState);
+        this.undoStack.push(this.options.clone(this.state));
+        this.state = this.options.clone(newState);
         this.redoStack = [];
         this.changeCount++;
         this.metrics.totalChanges++;
@@ -100,7 +102,7 @@ export class StateManager<TState extends object> {
      * Create a snapshot of the current state
      */
     createSnapshot(): void {
-        this.snapshots.push(structuredClone(this.state));
+        this.snapshots.push(this.options.clone(this.state));
     }
 
     /**
@@ -118,7 +120,7 @@ export class StateManager<TState extends object> {
     undo(): void {
         if (this.undoStack.length > 0) {
             const prev = this.undoStack.pop()!;
-            this.redoStack.push(structuredClone(this.state));
+            this.redoStack.push(this.options.clone(this.state));
             this.state = prev;
             this.metrics.undoOperations++;
         }
@@ -130,7 +132,7 @@ export class StateManager<TState extends object> {
     redo(): void {
         if (this.redoStack.length > 0) {
             const next = this.redoStack.pop()!;
-            this.undoStack.push(structuredClone(this.state));
+            this.undoStack.push(this.options.clone(this.state));
             this.state = next;
             this.metrics.redoOperations++;
         }

--- a/src/__tests__/StateManager.test.ts
+++ b/src/__tests__/StateManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { StateManager } from '../StateManager';
 
 interface TestState {
@@ -60,5 +60,19 @@ describe('StateManager', () => {
         // Should not be able to redo to state1 anymore
         stateManager.redo();
         expect(stateManager.getState()).toEqual(state2);
+    });
+
+    it('should respect custom clone function', () => {
+        const customClone = vi.fn(<T>(value: T) => JSON.parse(JSON.stringify(value)) as T);
+        const manager = new StateManager(initialState, { clone: customClone });
+
+        const newState = { count: 1, name: 'updated' };
+        manager.setState(newState);
+        manager.createSnapshot();
+        manager.undo();
+        manager.redo();
+
+        // constructor + setState (2) + createSnapshot + undo + redo
+        expect(customClone).toHaveBeenCalledTimes(6);
     });
 });


### PR DESCRIPTION
## Summary
- add optional `clone` function to `StateManagerOptions` with `structuredClone` fallback
- replace direct `structuredClone` usage with configured clone function across `StateManager`
- cover custom clone behavior with new unit test

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688f7d0957dc8325a20ca9b774b8951a