### PR TITLE
docs: clarify logging middleware events

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,8 +34,9 @@ export function loadPersistedState<TState extends object>(
 }
 
 /**
- * Creates a logging middleware that logs transaction and step events
- * with proper state type inference
+ * Creates a logging middleware that logs transaction lifecycle events
+ * (start, completion, and failure with execution time) with proper state type inference.
+ * Does not log individual transaction steps.
  */
 export function createLoggingMiddleware<TState extends object>(): Middleware<TState, unknown> {
     return async (ctx, next) => {


### PR DESCRIPTION
## Summary
- clarify logging middleware logs only transaction start, completion (with timing), and failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7d8e9fd08325895fb02a0192566b