### PR TITLE
docs: clarify transaction builder return

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,12 +235,14 @@ try {
 ### SagaManager
 
 - `static create<TState>(initialState: TState): SagaManager<TState>`
-- `createTransaction<TPayload>(name: string): Transaction<TState, TPayload>`
+- `createTransaction<TPayload>(name: string): TransactionBuilder<TState, TPayload>`
 - `use<TPayload>(middleware: Middleware<TState, TPayload>): void`
 - `on(event: string, callback: Listener): void`
 - `getState(): TState`
 - `undo(): void`
 - `redo(): void`
+
+The `createTransaction` method returns a `TransactionBuilder`, allowing you to configure steps before running the transaction.
 
 ### Transaction
 


### PR DESCRIPTION
## Summary
- document SagaManager#createTransaction returning TransactionBuilder
- note that createTransaction yields a builder for adding steps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7d8632708325b8fa485687d4e5f7