### PR TITLE
docs: update API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,10 @@ try {
 ### SagaManager
 
 - `static create<TState>(initialState: TState): SagaManager<TState>`
-- `createTransaction<TPayload>(name: string): Transaction<TState, TPayload>`
-- `use<TPayload>(middleware: Middleware<TState, TPayload>): void`
-- `on(event: string, callback: Listener): void`
+- `createTransaction<TPayload = unknown>(name: string): TransactionBuilder<TState, TPayload>`
+- `createVoidTransaction(name: string): Transaction<TState, void>`
+- `use(middleware: AnyMiddleware<TState>): void`
+- `onEvent(eventType: string, listener: SagaEventListener): void` _(replaces deprecated `on` method)_
 - `getState(): TState`
 - `undo(): void`
 - `redo(): void`


### PR DESCRIPTION
## Summary
- document `onEvent` listener and deprecate `on`
- clarify `createTransaction` return type and add `createVoidTransaction`
- update `use` signature in API reference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f7d68d3d8832594af32952911ce93