### PR TITLE
Use deep equality for transaction state comparison

### DIFF
--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -3,6 +3,7 @@ import type { StateManager } from './StateManager';
 import { TransactionExecutor } from './TransactionExecutor';
 import { TransactionRollback } from './TransactionRollback';
 import { MiddlewareOrchestrator } from './MiddlewareOrchestrator';
+import { deepEqual } from './ReactiveSelectors';
 
 // Forward declaration to avoid circular dependency
 interface EventEmitter {
@@ -196,7 +197,7 @@ export class Transaction<TState extends object, TPayload = unknown> {
 
         // After successful execution, if state has changed, add it to undo stack
         const finalState = this.stateManager.getState();
-        if (JSON.stringify(initialState) !== JSON.stringify(finalState)) {
+        if (!deepEqual(initialState, finalState)) {
           this.stateManager.addToUndoStack(initialState);
         }
 

--- a/src/__tests__/Transaction.test.ts
+++ b/src/__tests__/Transaction.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { StateManager } from '../StateManager';
 import { SagaManager } from '../SagaManager';
 import { Transaction } from '../Transaction';
+import { deepEqual } from '../ReactiveSelectors';
 
 interface TestState {
     counter: number;
@@ -157,6 +158,44 @@ describe('Transaction', () => {
                 'step:rollback',
                 'transaction:rollback'
             ]);
+        });
+
+        it('should not add to undo stack when final state is deeply equal but ordered differently', async () => {
+            interface ComplexState {
+                first: string;
+                second: string;
+                nested: { foo: number; bar: number };
+            }
+
+            const complexInitial: ComplexState = {
+                first: 'one',
+                second: 'two',
+                nested: { foo: 1, bar: 2 }
+            };
+
+            const complexSaga = SagaManager.create(complexInitial);
+            const complexTransaction = complexSaga.createTypedTransaction<void>('complex');
+
+            complexTransaction.addStep('reorder', (state) => {
+                const { first, second, nested } = state;
+                delete (state as any).first;
+                delete (state as any).second;
+                delete (state as any).nested;
+                (state as any).nested = { bar: nested.bar, foo: nested.foo };
+                (state as any).second = second;
+                (state as any).first = first;
+            });
+
+            await complexTransaction.run(undefined);
+
+            const finalState = complexSaga.getState();
+
+            // Stringified versions differ due to property order
+            expect(JSON.stringify(finalState)).not.toBe(JSON.stringify(complexInitial));
+            // Deep equality still holds
+            expect(deepEqual(finalState, complexInitial)).toBe(true);
+            // Undo stack should remain empty since state hasn't truly changed
+            expect(complexSaga.stateManager.undoStackLength).toBe(0);
         });
     });
 


### PR DESCRIPTION
## Summary
- use `deepEqual` helper in `Transaction.run` instead of JSON string comparison
- add test ensuring undo stack is not updated when state is only reordered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f7cfba1648325b688866525fad54c