### PR TITLE
Add SagaManager cleanup method and dispose timers

### DIFF
--- a/examples/advanced-features-demo.ts
+++ b/examples/advanced-features-demo.ts
@@ -438,3 +438,6 @@ export {
     complexOrderFlow,
     orderWithFallback
 };
+
+// Clean up the saga manager to avoid dangling timers
+saga.dispose();

--- a/examples/automatic-payload-inference-demo.ts
+++ b/examples/automatic-payload-inference-demo.ts
@@ -231,5 +231,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    demonstrateAutomaticInference().catch(console.error);
+    demonstrateAutomaticInference().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -215,7 +215,7 @@ async function runExamples() {
 
 // Run the examples
 if (import.meta.url === `file://${process.argv[1]}`) {
-    runExamples().catch(console.error);
+    runExamples().catch(console.error).finally(() => saga.dispose());
 }
 
 export { runExamples };

--- a/examples/explicit-payload-typing-demo.ts
+++ b/examples/explicit-payload-typing-demo.ts
@@ -278,5 +278,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    demonstrateExplicitTyping().catch(console.error);
+    demonstrateExplicitTyping().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/no-unknown-payload-demo.ts
+++ b/examples/no-unknown-payload-demo.ts
@@ -275,5 +275,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    demonstrateNoUnknownPayloads().catch(console.error);
+    demonstrateNoUnknownPayloads().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/payload-inference-demo.ts
+++ b/examples/payload-inference-demo.ts
@@ -333,5 +333,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    runPayloadInferenceDemo().catch(console.error);
+    runPayloadInferenceDemo().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/pure-generics-demo.ts
+++ b/examples/pure-generics-demo.ts
@@ -233,5 +233,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    demonstratePureGenerics().catch(console.error);
+    demonstratePureGenerics().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/redux-patterns-demo.ts
+++ b/examples/redux-patterns-demo.ts
@@ -421,5 +421,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    runReduxPatternsDemo().catch(console.error);
+    runReduxPatternsDemo().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/smart-payload-inference-demo.ts
+++ b/examples/smart-payload-inference-demo.ts
@@ -273,5 +273,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    demonstrateSmartInference().catch(console.error);
+    demonstrateSmartInference().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/transaction-patterns-demo.ts
+++ b/examples/transaction-patterns-demo.ts
@@ -229,5 +229,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    runTransactionPatterns().catch(console.error);
+    runTransactionPatterns().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/type-safe-usage.ts
+++ b/examples/type-safe-usage.ts
@@ -379,5 +379,5 @@ export {
 
 // Run demo if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-    runTypeSafeDemo().catch(console.error);
+    runTypeSafeDemo().catch(console.error).finally(() => saga.dispose());
 }

--- a/examples/type-safety-demo.ts
+++ b/examples/type-safety-demo.ts
@@ -167,3 +167,6 @@ export {
 };
 
 console.log('\n🎉 Type Safety Demo Complete - Zero "as any" casts used!');
+
+// Clean up the saga manager to avoid dangling timers
+saga.dispose();

--- a/src/SagaManager.ts
+++ b/src/SagaManager.ts
@@ -25,6 +25,9 @@ export class SagaManager<TState extends object> {
   // Event replay system
   private replayManager: EventReplayManager<unknown>;
 
+  // Interval ID for state change watcher
+  private stateWatchInterval: ReturnType<typeof setInterval> | null = null;
+
   // Expose StateManager for testing without type casting
   public get stateManager(): StateManager<TState> {
     return this._stateManager;
@@ -318,7 +321,17 @@ export class SagaManager<TState extends object> {
     });
 
     // Also check periodically (fallback)
-    setInterval(checkForChanges, 100);
+    this.stateWatchInterval = setInterval(checkForChanges, 100);
+  }
+
+  /**
+   * Clean up resources used by the saga manager
+   */
+  dispose(): void {
+    if (this.stateWatchInterval !== null) {
+      clearInterval(this.stateWatchInterval);
+      this.stateWatchInterval = null;
+    }
   }
 
   // ===== REACTIVE SELECTOR METHODS =====

--- a/src/__tests__/SagaManager.test.ts
+++ b/src/__tests__/SagaManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SagaManager } from '../SagaManager';
 
 interface TestState {
@@ -12,6 +12,10 @@ describe('SagaManager', () => {
 
     beforeEach(() => {
         saga = SagaManager.create(initialState);
+    });
+
+    afterEach(() => {
+        saga.dispose();
     });
 
     it('should create with initial state', () => {

--- a/src/__tests__/Transaction.test.ts
+++ b/src/__tests__/Transaction.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StateManager } from '../StateManager';
 import { SagaManager } from '../SagaManager';
 import { Transaction } from '../Transaction';
@@ -26,6 +26,10 @@ describe('Transaction', () => {
         stateManager = sagaManager.stateManager;
         // Use createTypedTransaction for legacy test compatibility
         transaction = sagaManager.createTypedTransaction<TestPayload>('test-transaction');
+    });
+
+    afterEach(() => {
+        sagaManager.dispose();
     });
 
     describe('addStep', () => {

--- a/src/__tests__/edge-cases.test.ts
+++ b/src/__tests__/edge-cases.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SagaManager, StateManager, Transaction } from '../index';
 
 interface TestState {
@@ -23,6 +23,10 @@ describe('Edge Cases and Error Handling', () => {
 
   beforeEach(() => {
     saga = SagaManager.create(initialState);
+  });
+
+  afterEach(() => {
+    saga.dispose();
   });
 
   describe('State Management Edge Cases', () => {
@@ -101,6 +105,8 @@ describe('Edge Cases and Error Handling', () => {
       expect(nullableSaga.getState().value).toBe(42);
       expect(nullableSaga.getState().optional).toBe('defined');
       expect(nullableSaga.getState().items).toEqual([null, undefined]);
+
+      nullableSaga.dispose();
     });
 
     it('should handle large state objects', async () => {
@@ -123,6 +129,8 @@ describe('Edge Cases and Error Handling', () => {
 
       expect(largeSaga.getState().count).toBe(10000);
       expect(largeSaga.getState().items).toHaveLength(10001);
+
+      largeSaga.dispose();
     });
   });
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SagaManager, createPersistenceMiddleware, createLoggingMiddleware, createTimingMiddleware } from '../index';
 
 interface EcommerceState {
@@ -34,6 +34,10 @@ describe('Integration Tests', () => {
   beforeEach(() => {
     saga = SagaManager.create(initialState);
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    saga.dispose();
   });
 
   describe('E-commerce Order Processing', () => {

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -33,6 +33,10 @@ describe('Middleware', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    saga.dispose();
+  });
+
   describe('createPersistenceMiddleware', () => {
     it('should save state to localStorage after successful transaction', async () => {
       const middleware = createPersistenceMiddleware<TestState>('test-key');


### PR DESCRIPTION
## Summary
- Track SagaManager's state watch interval and expose a `dispose()` cleanup method
- Ensure tests dispose SagaManager instances to prevent lingering timers
- Update examples to dispose SagaManager after running demos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7cf68d54832584bee3943722ee44