### PR TITLE
fix: avoid structuredClone illegal invocation in StateManager

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -61,7 +61,7 @@ export class StateManager<TState extends object> {
             maxSnapshots: options.maxSnapshots ?? 20,
             autoCleanup: options.autoCleanup ?? true,
             snapshotInterval: options.snapshotInterval ?? 10,
-            clone: options.clone ?? structuredClone
+            clone: options.clone ?? ((value) => structuredClone(value))
         };
 
         this.state = this.options.clone(initialState);


### PR DESCRIPTION
## Summary
- ensure default clone function wraps structuredClone to avoid illegal invocation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890ba09c69c8325972adb78a59b363e