### PR TITLE
fix: correct ESM/CJS exports, improve cloning, encapsulation, CI, and…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npm run type-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Package module resolution.** `package.json` `exports` now correctly routes
+  `import` to the ESM bundle (`dist/index.mjs`) and `require` to the CJS bundle
+  (`dist/index.js`). Previously both pointed to the CJS file, so ESM consumers
+  received CommonJS output. The `module` field was also corrected and a `types`
+  condition was added to the `exports` map.
+- **Consistent deep cloning.** `SagaManager.recordEvent()` now uses
+  `StateManager.clone()` and `Store.setDraft()` now uses the statekit `deepClone`
+  utility instead of `JSON.parse(JSON.stringify(...))`. This preserves `undefined`
+  values in arrays and leverages `structuredClone` when available.
+- **Encapsulation.** `Transaction.run()` now accesses the configured equality
+  function via the new public `StateManager.getEqualityFn()` method instead of
+  reading the private `options` field through an `as any` cast.
 - **Reactive selectors stay in sync with undo/rollback.** `StateManager.undo()`
   and `rollbackToLastSnapshot()` now propagate through the reactive core, so
   `select()`-based signals no longer report stale values (previously only
@@ -28,6 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI.** The test workflow now runs against a Node.js 20 **and** 22 matrix to
+  verify compatibility with current LTS releases.
+- **Tooling.** Added `.editorconfig` for consistent formatting across editors
+  and a V8 coverage configuration in `vitest.config.ts` (run
+  `npm i -D @vitest/coverage-v8 && vitest run --coverage` to collect metrics).
+- **Tree-shaking.** Declared `"sideEffects": false` in `package.json` so
+  bundlers can safely eliminate unused exports.
 - **Documentation.** Corrected the install/import name to `@staga/core` and
   significantly expanded the README (statekit primitives, configuration
   options, selectors & computed values, metrics, error handling, DI, plugins).

--- a/package.json
+++ b/package.json
@@ -3,14 +3,16 @@
     "version": "1.0.0",
     "description": "A TypeScript library for managing state transactions with saga pattern, rollbacks, and middleware support",
     "main": "dist/index.js",
-    "module": "dist/index.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.mjs",
             "require": "./dist/index.js"
         }
     },
+    "sideEffects": false,
     "files": [
         "dist",
         "README.md",

--- a/src/SagaManager.ts
+++ b/src/SagaManager.ts
@@ -60,7 +60,7 @@ export class SagaManager<TState extends object> {
             type,
             payload,
             timestamp: Date.now(),
-            stateSnapshot: JSON.parse(JSON.stringify(stateSnapshot)) // Deep clone to preserve snapshot
+            stateSnapshot: this._stateManager.clone(stateSnapshot)
         });
     }
 

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -486,6 +486,13 @@ export class StateManager<TState extends object> {
     }
 
     /**
+     * Expose the configured equality function for internal consumers like Transaction
+     */
+    public getEqualityFn(): <T>(a: T, b: T) => boolean {
+        return this.options.equalityFn;
+    }
+
+    /**
      * Default deep clone that preserves undefined values in arrays and objects
      */
     private defaultClone<T>(value: T): T {

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -173,8 +173,8 @@ export class Transaction<TState extends object, TPayload = unknown> {
 
 
   /**
- * Execute the transaction with all its steps
- */
+   * Execute the transaction with all its steps
+   */
   async run(payload: TPayload): Promise<void> {
     const startTime = Date.now();
 
@@ -219,7 +219,7 @@ export class Transaction<TState extends object, TPayload = unknown> {
 
         // After successful execution, if state has changed, add it to undo stack
         const finalState = this.stateManager.getState();
-        const eq = this.options.equalityFn ?? ((this.stateManager as any)['options'].equalityFn as (a: TState, b: TState) => boolean);
+        const eq = this.options.equalityFn ?? this.stateManager.getEqualityFn();
         if (!eq(initialState, finalState)) {
           this.stateManager.addToUndoStack(initialState);
         }

--- a/src/statekit/store.ts
+++ b/src/statekit/store.ts
@@ -1,4 +1,5 @@
 import type { EqualityFn, Unsubscribe } from './utils';
+import { deepClone } from './utils';
 import type { Priority, Scheduler } from './scheduler';
 import type { StateMiddleware, TxEventMiddleware, SetStateAction } from './middlewares';
 
@@ -39,8 +40,7 @@ export class Store<S extends object> {
     }
 
     setDraft(recipe: (draft: S) => void, action?: SetStateAction, options?: SetStateOptions) {
-        const base = this.state as S;
-        const draft = JSON.parse(JSON.stringify(base)) as S;
+        const draft = deepClone(this.state);
         recipe(draft);
         this.setStateInternal(draft, action, options);
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,19 @@ export default defineConfig({
         environment: 'node',
         include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
         exclude: ['node_modules', 'dist'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.ts'],
+            exclude: [
+                'src/**/*.test.ts',
+                'src/**/*.spec.ts',
+                'src/**/index.ts',
+                'src/plugins/examples/**',
+                'src/di/index.ts',
+                'src/managers/index.ts',
+                'src/plugins/index.ts',
+                'src/statekit/index.ts',
+            ],
+        },
     },
 });


### PR DESCRIPTION
… tooling

- package.json: route import->ESM (.mjs), require->CJS (.js), add types condition and sideEffects:false for proper tree-shaking
- SagaManager.recordEvent: use StateManager.clone() instead of JSON.parse/stringify
- Store.setDraft: use deepClone utility instead of JSON.parse/stringify
- StateManager: expose getEqualityFn() for encapsulation
- Transaction.run: use getEqualityFn() instead of private field access via any
- CI: add Node.js 22 to test matrix
- vitest.config: add V8 coverage configuration (optional @vitest/coverage-v8)
- Add .editorconfig for consistent cross-editor formatting