### PR TITLE
fix(demo): resolve npm ci lockfile failure for GH Pages deploy

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -7,9 +7,6 @@
         "": {
             "name": "staga-demo",
             "version": "1.0.0",
-            "dependencies": {
-                "@staga/core": "file:.."
-            },
             "devDependencies": {
                 "typescript": "^5.3.0",
                 "vite": "^5.4.0"
@@ -707,14 +704,6 @@
             "os": [
                 "win32"
             ]
-        },
-        "node_modules/@staga/core": {
-            "version": "1.0.0",
-            "resolved": "file:..",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.0.0"
-            }
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,9 +8,6 @@
         "build": "vite build",
         "preview": "vite preview"
     },
-    "dependencies": {
-        "@staga/core": "file:.."
-    },
     "devDependencies": {
         "typescript": "^5.3.0",
         "vite": "^5.4.0"


### PR DESCRIPTION
## Problem

The `Deploy Demo to GitHub Pages` workflow fails at `npm ci` in the demo directory:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: @staga/core@1.0.0 from lock file
```

## Root Cause

`demo/package.json` declared `"@staga/core": "file:.."` as a dependency, but the resolved lock file entry (`resolved: "file:.."`) fails `npm ci` in CI environments.

## Fix

The npm dependency is redundant: Vite resolves `@staga/core` via `resolve.alias` in `vite.config.ts` (→ `../src/index.ts`), and `tsconfig.json` has the matching path mapping. Removing it and regenerating the lock file fixes `npm ci`.

## Verification
- `npm ci` in demo/ now succeeds (exit 0)
- `npm run build` in demo/ produces 32 modules, 0 errors
- 180 library tests pass (no regression)